### PR TITLE
fix: update x-axis label and color mapping for quarterly production plot

### DIFF
--- a/pages/Comparative_Production.py
+++ b/pages/Comparative_Production.py
@@ -149,9 +149,9 @@ def plotly_quarterly_comparative_production():
     year_quarter_df = q.collect()
     fig = px.bar(
         year_quarter_df,
-        x="year",
+        x="Quarter",
         y="Quarterly_Production",
-        color="Quarter",
+        color="year",
         barmode="group",
     )
     fig.update_layout(xaxis_title="Quarter", yaxis_title="Quarterly Production (kWh)")


### PR DESCRIPTION
adjust comparative quarterly production to have x axis be Quarter instead of year. 